### PR TITLE
ci: replace split Slack notify steps with a single dynamic-status one

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -52,32 +52,41 @@ steps:
     when:
       - status: [success]
 
-  # Same fork/build of GowerStreet/woodpecker-slack as the other repos'
-  # pipelines - status still set explicitly per step since Woodpecker
-  # doesn't expose CI_PIPELINE_STATUS as a container env var
-  # (woodpecker-ci/woodpecker#4337).
-  - name: notify-slack-success
-    image: ghcr.io/modem7/woodpecker-slack:latest
-    pull: true
+  # Single dynamic-status notifier, replacing notify-slack-success/failure.
+  # CI_PIPELINE_STATUS must stay bare ($VAR, not ${VAR}) - Woodpecker
+  # resolves ${VAR} at compile time, before this value exists
+  # (woodpecker-ci/woodpecker#6826).
+  - name: notify-slack
+    image: alpine
     depends_on:
       - build-and-push
-    settings:
-      status: success
-      description: docker-starwars build
-      webhook:
+    environment:
+      SLACK_WEBHOOK:
         from_secret: slack_hook
+    commands:
+      - apk add --no-cache curl jq >/dev/null
+      - COMMIT_SHORT=$(echo "$CI_COMMIT_SHA" | cut -c1-10)
+      - >
+        PAYLOAD=$(jq -n
+        --arg status "$CI_PIPELINE_STATUS"
+        --arg branch "$CI_COMMIT_BRANCH"
+        --arg output "${CI_REPO}#${CI_PIPELINE_NUMBER}"
+        --arg output_url "$CI_PIPELINE_URL"
+        --arg build "$CI_PIPELINE_NUMBER"
+        --arg commit "$COMMIT_SHORT"
+        --arg commit_url "$CI_PIPELINE_FORGE_URL"
+        --arg author "$CI_COMMIT_AUTHOR"
+        --arg message "$CI_COMMIT_MESSAGE"
+        '{attachments:[{color:(if $status == "success" then "good" else "danger" end),fields:[
+        {title:"Status",value:$status,short:true},
+        {title:"Branch",value:$branch,short:true},
+        {title:"Output",value:("<"+$output_url+"|"+$output+">"),short:true},
+        {title:"Build Number",value:$build,short:true},
+        {title:"Commit",value:("<"+$commit_url+"|"+$commit+">"),short:true},
+        {title:"Author",value:$author,short:true},
+        {title:"Commit Message",value:$message,short:false}
+        ]}]}')
+      - >
+        curl -fsS -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK"
     when:
-      - status: [success]
-
-  - name: notify-slack-failure
-    image: ghcr.io/modem7/woodpecker-slack:latest
-    pull: true
-    depends_on:
-      - build-and-push
-    settings:
-      status: failure
-      description: docker-starwars build
-      webhook:
-        from_secret: slack_hook
-    when:
-      - status: [failure]
+      - status: [success, failure]


### PR DESCRIPTION
## Summary
- `notify-slack-success`/`notify-slack-failure` hardcoded `settings.status` per step and depended on our own `ghcr.io/modem7/woodpecker-slack` image, because `CI_PIPELINE_STATUS` appeared broken as a container env var.
- Root cause found and confirmed with a maintainer: [woodpecker-ci/woodpecker#6826](https://github.com/woodpecker-ci/woodpecker/issues/6826) — Woodpecker resolves `${VAR}` at compile time, before per-step runtime values like `CI_PIPELINE_STATUS` exist. Bare `$VAR` (no braces) works correctly, since it's left for the container's shell to expand at actual runtime.
- Replaces both steps with a single `notify-slack` step using `jq`/`curl`, reading `$CI_PIPELINE_STATUS` (bare) directly. Also restores the richer Branch/Output/Build Number/Commit/Author/Commit Message attachment layout from the original Drone-era message.

## Test plan
- [x] Verified end-to-end on a throwaway branch against the live `woodpecker.modem7.com` instance: failure path renders `"color": "danger"`, `"value": "failure"`; success path renders `"color": "good"`, `"value": "success"` — confirmed via the actual JSON payload before posting.
- [x] Both real Slack messages posted correctly during testing (clearly marked as test runs).
- [ ] Merge and confirm the real pipeline notification renders correctly on the next master build.