### PR TITLE
Extend shared renovate-config and settings defaults

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,3 +1,4 @@
+_extends: .github
 # https://github.com/apps/settings
 # https://github.com/repository-settings/app
 
@@ -27,36 +28,6 @@ repository:
 
 # Labels: define labels for Issues and Pull Requests
 labels:
-  - name: bug
-    color: d73a4a
-    description: "Something isn't working"
   - name: content-freshness
     color: fbca04
     description: "The mirrored asciimation content is out of date with upstream"
-  - name: dependencies
-    color: C62109
-    description: "Pull requests that update a dependency file"
-  - name: documentation
-    color: "0075ca"
-    description: "Improvements or additions to documentation"
-  - name: duplicate
-    color: cfd3d7
-    description: "This issue or pull request already exists"
-  - name: enhancement
-    color: a2eeef
-    description: "New feature or request"
-  - name: good first issue
-    color: "7057ff"
-    description: "Good for newcomers"
-  - name: help wanted
-    color: "008672"
-    description: "Extra attention is needed"
-  - name: invalid
-    color: e4e669
-    description: "This doesn't seem right"
-  - name: question
-    color: d876e3
-    description: "Further information is requested"
-  - name: wontfix
-    color: ffffff
-    description: "This will not be worked on"

--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "assignees": [
-    "modem7"
-  ],
-  "labels": [
-    "dependencies"
-  ],
-  "timezone": "Europe/London"
+  "extends": ["github>modem7/renovate-config"]
 }


### PR DESCRIPTION
## Summary

- `renovate.json` now extends the shared `modem7/renovate-config` preset instead of duplicating the same `config:recommended` / assignees / labels / timezone boilerplate that's copy-pasted across ~15 of modem7's repos.
- `.github/settings.yml` now adds `_extends: .github` so the standard label set (bug, dependencies, documentation, duplicate, enhancement, good first issue, help wanted, invalid, question, wontfix) is inherited from `modem7/.github` instead of being duplicated here. The repo-specific `content-freshness` label (not part of the shared default set) is kept as a local addition in the `labels:` section — the Repository Settings App merges label arrays by `name`, so it combines with the inherited defaults. The `repository:` block is untouched.

## Notes

- This depends on [modem7/renovate-config#6](https://github.com/modem7/renovate-config/pull/6) merging for the new `extends` target to take full effect. Until then, `github>modem7/renovate-config` still resolves to the existing (pre-PR) config content, which is harmless — the extends reference itself is correct now and will pick up the final config automatically once #6 merges.
- `modem7/.github` is already merged to its default branch, so the settings inheritance takes effect immediately.