### PR TITLE
fix(ci): close unterminated if/else in content-freshness workflow

### DIFF
--- a/.github/workflows/content-freshness.yml
+++ b/.github/workflows/content-freshness.yml
@@ -42,6 +42,7 @@ jobs:
               --title "Asciimation content is out of date" \
               --label content-freshness \
               --body "The scheduled content-freshness check found that \`src/index.html\`'s film data no longer matches upstream (https://www.asciimation.co.nz/Blinkenlights/). Run \`python3 scripts/update_film_data.py\`, review the diff, rebuild/test the image, and open a PR. This issue will need to be closed manually once that's done - the check doesn't auto-close it, to avoid closing an issue someone is still actively working."
+          fi
 
       - name: Fail the job if stale
         if: steps.freshness.outcome == 'failure'


### PR DESCRIPTION
## Summary
- The \`Open tracking issue if stale\` step's shell script opens an \`if/else\` block on line 38 but never closes it with \`fi\`, so bash fails with \`unexpected end of file\` any time \`check_film_freshness.py\` reports stale content.
- Adds the missing \`fi\`.

Fixes the failure seen in [run 30801769493](https://github.com/modem7/docker-starwars/actions/runs/30801769493/job/91647728526).

## Test plan
- [ ] Trigger the workflow via \`workflow_dispatch\` and confirm the "Open tracking issue if stale" step no longer errors on syntax