### PR TITLE
ci(security): pin hadolint image by tag and digest

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,5 +20,6 @@ jobs:
 
       - name: Run hadolint
         run: |
-          docker run --rm -v "$PWD":/work -w /work hadolint/hadolint:latest-alpine \
+          docker run --rm -v "$PWD":/work -w /work \
+            hadolint/hadolint:v2.15.1-alpine@sha256:a1d49ae1a4e83c1dbad26b8c1ad7588c8bd1e04f4866b34ad3cac50335198552 \
             sh -c "hadolint --version && hadolint Dockerfile"


### PR DESCRIPTION
## Summary
Follow-up to #83, which was merged just before this fix landed.

- \`.github/workflows/lint.yml\` referenced \`hadolint/hadolint:latest-alpine\`, a mutable tag — the image content can change underneath CI runs without any review, a supply-chain risk flagged by an automated commit security review.
- Pins to \`hadolint/hadolint:v2.15.1-alpine@sha256:a1d49ae1a4e83c1dbad26b8c1ad7588c8bd1e04f4866b34ad3cac50335198552\` so the exact image is reproducible; bumping it now requires an explicit, reviewable change.

## Test plan
- [x] Ran the pinned image locally against \`Dockerfile\`: passes (hadolint 2.15.1, exit 0)
- [ ] Confirm the \`hadolint\` GitHub Actions check passes on this PR