### PR TITLE
ci: auto-assign content-freshness tracking issues to modem7

### DIFF
--- a/.github/workflows/content-freshness.yml
+++ b/.github/workflows/content-freshness.yml
@@ -41,6 +41,7 @@ jobs:
             gh issue create \
               --title "Asciimation content is out of date" \
               --label content-freshness \
+              --assignee modem7 \
               --body "The scheduled content-freshness check found that \`src/index.html\`'s film data no longer matches upstream (https://www.asciimation.co.nz/Blinkenlights/). Run \`python3 scripts/update_film_data.py\`, review the diff, rebuild/test the image, and open a PR. This issue will need to be closed manually once that's done - the check doesn't auto-close it, to avoid closing an issue someone is still actively working."
           fi
 


### PR DESCRIPTION
## Summary
- The `content-freshness.yml` scheduled workflow creates tracking issues via `gh issue create` using the default `GITHUB_TOKEN`, which by design does not trigger other `on: issues` workflows (GitHub's recursion guard) — so `autoassign.yml` never ran for these issues (see #85).
- Fix by assigning directly in the same step with `--assignee modem7` instead of routing around the recursion guard with a PAT.

## Test plan
- [ ] Confirm the workflow YAML is valid (lint/CI passes)
- [ ] Manually trigger `content-freshness.yml` via `workflow_dispatch` against a stale-data scenario (or wait for next scheduled run) and confirm the created issue is assigned to modem7