### PR TITLE
ci: auto-trigger update-film-data PR when content is stale

### DIFF
--- a/.github/workflows/content-freshness.yml
+++ b/.github/workflows/content-freshness.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: read
   issues: write
+  actions: write
 
 jobs:
   check:
@@ -42,8 +43,14 @@ jobs:
               --title "Asciimation content is out of date" \
               --label content-freshness \
               --assignee modem7 \
-              --body "The scheduled content-freshness check found that \`src/index.html\`'s film data no longer matches upstream (https://www.asciimation.co.nz/Blinkenlights/). Run \`python3 scripts/update_film_data.py\`, review the diff, rebuild/test the image, and open a PR. This issue will need to be closed manually once that's done - the check doesn't auto-close it, to avoid closing an issue someone is still actively working."
+              --body "The scheduled content-freshness check found that \`src/index.html\`'s film data no longer matches upstream (https://www.asciimation.co.nz/Blinkenlights/). The \"Update film data\" workflow has been triggered automatically to open a PR with the refresh. This issue will need to be closed manually once that PR is merged - the check doesn't auto-close it, to avoid closing an issue someone is still actively working."
           fi
+
+      - name: Trigger automated update PR
+        if: steps.freshness.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run update-film-data.yml --ref master
 
       - name: Fail the job if stale
         if: steps.freshness.outcome == 'failure'

--- a/.github/workflows/update-film-data.yml
+++ b/.github/workflows/update-film-data.yml
@@ -52,7 +52,8 @@ jobs:
           gh pr create \
             --title "Update asciimation film data from upstream" \
             --label content-freshness \
-            --body "Triggered manually via the \"Update film data\" workflow. Pulls the current film array + footer note from https://www.asciimation.co.nz/Blinkenlights/ via \`scripts/update_film_data.py\`, leaving engine code and the deliberately-excluded ads/tracking/dead-links untouched. Review the diff and let the Test workflow finish before merging."
+            --assignee modem7 \
+            --body "Triggered via the \"Update film data\" workflow (manually, or automatically by the content-freshness check). Pulls the current film array + footer note from https://www.asciimation.co.nz/Blinkenlights/ via \`scripts/update_film_data.py\`, leaving engine code and the deliberately-excluded ads/tracking/dead-links untouched. Review the diff and let the Test workflow finish before merging."
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary
- The content-freshness check previously only opened a tracking issue telling someone to run `update_film_data.py` manually and open a PR by hand.
- Now it also dispatches the existing `update-film-data.yml` workflow (`workflow_dispatch` is exempt from GitHub's `GITHUB_TOKEN` recursion guard, unlike `issues`/`push`), which runs the script and opens the PR itself — skipping if one's already open.
- Also assign that auto-opened PR to modem7 directly, since PR creation via the default token still won't fire `autoassign.yml` (same root cause as #85/#87).

## Test plan
- [ ] Manually run `content-freshness.yml` via `workflow_dispatch` (data is currently stale — see #85) and confirm it triggers `update-film-data.yml`, which opens a PR assigned to modem7
- [ ] Confirm re-running while a PR is already open is a no-op (existing skip guard in `update-film-data.yml`)