### PR TITLE
ci: allow manual dispatch of the renovate PR assignment job

### DIFF
--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -7,6 +7,7 @@ on:
     types: [opened]
   schedule:
     - cron: '0 */6 * * *'
+  workflow_dispatch: {}
 
 jobs:
   auto-assign-issue:
@@ -33,7 +34,7 @@ jobs:
             assignees: modem7
 
   auto-assign-stale-renovate-pr:
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
Adds `workflow_dispatch` so the scheduled Renovate-PR-assignment job can be triggered on demand for testing.